### PR TITLE
Updating version of the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To set up Snowflake credentials for a specific connection follow these steps.
    - Add the `default-config-file-path` parameter to the Snowflake CLI action step in your workflow file. This specifies the path to your `config.toml` file. For example:
 
      ```yaml
-     - uses: snowflakedb/snowflake-cli-action@v1
+     - uses: snowflakedb/snowflake-cli-action@v1.5
        with:
          cli-version: "latest"
          default-config-file-path: "config.toml"


### PR DESCRIPTION
The **v1** does not exist any more so that sample will fail.
Or alternatively maybe you can add the **v1** tag to track the latest **v1.*** release. (Ref on GitHub docs [here](https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions#using-tags-for-release-management))