### PR TITLE
fix: [SNOW-2131839] Handle providing CLI_VERSION=latest

### DIFF
--- a/scripts/install-snowcli.sh
+++ b/scripts/install-snowcli.sh
@@ -22,7 +22,7 @@ if [ -n "${CUSTOM_GITHUB_REF:-}" ]; then
         --python "$PYTHON_PATH" \
         --force \
         "git+https://github.com/snowflakedb/snowflake-cli.git@${CUSTOM_GITHUB_REF}"
-elif [ -n "${CLI_VERSION:-}" ]; then
+elif [ -n "${CLI_VERSION:-}" ] && [ "${CLI_VERSION}" != "latest" ]; then
     pipx install snowflake-cli=="$CLI_VERSION" --python "$PYTHON_PATH"
 else
     pipx install snowflake-cli --python "$PYTHON_PATH"


### PR DESCRIPTION
Tests triggered from CLI are failing because we're explicitly passing CLI_VERSION=latest: 
https://github.com/snowflakedb/snowflake-cli/actions/runs/15430393433/workflow#L22
https://github.com/snowflakedb/snowflake-cli/actions/runs/15405402320