### PR TITLE
mraba/replace-tag-with-hash: ping setup-uv to sha for 7.1.6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: echo "SF_GITHUB_ACTION=true" >> "$GITHUB_ENV"
 
-    - uses: astral-sh/setup-uv@eb1897b8dc4b5d5bfe39a428a8f2304605e0983c #v7
+    - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 #v7.1.6
       with:
         python-version: "3.11"
 


### PR DESCRIPTION
Bump `setup-uv` to latest sha (7.1.6)