### PR TITLE
Add v2 to major tag update workflow

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -12,6 +12,7 @@ on:
         description: The major tag to update
         options:
           - v1
+          - v2
 
 jobs:
   tag:


### PR DESCRIPTION
## Summary
- Adds `v2` as an option in the `update-major-tag` workflow so we can maintain a floating `v2` tag
- Currently users must pin to `@v2.0` because no `v2` tag exists; the standard convention
(used by `actions/checkout`, etc.) is to offer `@v2` as a floating major version tag

## After merging
Run the "Update major tag" workflow with `tag=v2.0` and `major_tag=v2` to create the
initial `v2` tag pointing at the existing `v2.0` release. From then on, each new v2.x
release just needs that workflow re-run.

## Test plan
- [ ] Verify the workflow dispatch UI shows both `v1` and `v2` in the major_tag dropdown
- [ ] Run the workflow with `tag=v2.0`, `major_tag=v2` to create the floating `v2` tag
- [ ] Confirm `uses: snowflakedb/snowflake-cli-action@v2` resolves correctly