### PR TITLE
Add integration version telemetry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,9 @@ runs:
   steps:
     - name: add extra telemetry data
       shell: bash
-      run: echo "SF_GITHUB_ACTION=true" >> "$GITHUB_ENV"
+      run: |
+        echo "SF_GITHUB_ACTION=true" >> "$GITHUB_ENV"
+        echo "SF_CICD_INTEGRATION_VERSION=v2.0" >> "$GITHUB_ENV"
 
     - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 #v7.1.6
       with:

--- a/action.yml
+++ b/action.yml
@@ -37,9 +37,12 @@ runs:
   steps:
     - name: add extra telemetry data
       shell: bash
+      env:
+        # Bump on each release to match the repository tag
+        SF_CICD_INTEGRATION_VERSION: "v2.0"
       run: |
         echo "SF_GITHUB_ACTION=true" >> "$GITHUB_ENV"
-        echo "SF_CICD_INTEGRATION_VERSION=v2.0" >> "$GITHUB_ENV"
+        echo "SF_CICD_INTEGRATION_VERSION=$SF_CICD_INTEGRATION_VERSION" >> "$GITHUB_ENV"
 
     - uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 #v7.1.6
       with:


### PR DESCRIPTION
## Summary

Pass `SF_CICD_INTEGRATION_VERSION` env var alongside existing `SF_GITHUB_ACTION` so the Snowflake CLI can report which version of the GitHub Action is in use. This enables adoption tracking and BCR analysis for the Nucleus project.

## Changes

- Updated `action.yml` telemetry step to also set `SF_CICD_INTEGRATION_VERSION=v2.0`
- Version should be bumped alongside each release tag

## Related

- snowflakedb/snowflake-cli#2883 - CLI-side changes to read and report the new field
- snowflakedb/snowflake-ado-extension - companion PR adding same tracking for ADO
- snowflakedbutils/snowflake-cicd-component - companion MR adding same tracking for GitLab