### PR TITLE
Add main-branch reachability validation to update-major-tag workflow

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -39,6 +39,16 @@ jobs:
         env:
           TAG: ${{ github.event.inputs.tag }}
 
+      - name: Validate tag is reachable from main
+        run: |
+          TAG_COMMIT=$(git rev-parse "$TAG^{commit}")
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Tag $TAG points to commit $TAG_COMMIT which is not reachable from the main branch. Tags must only reference commits on main."
+            exit 1
+          fi
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+
       - name: Update tag
         run: git tag -f "$MAJOR_TAG" "$TAG"
         env:

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.TAG_ADMIN_TOKEN }}
 
       - name: Validate major tag format
         run: |

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -17,10 +17,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Verify caller is a repo admin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" ]]; then
+            echo "::error::Only repository admins can trigger this workflow. Current permission: $PERMISSION"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.TAG_ADMIN_TOKEN }}
 
       - name: Validate major tag format
         run: |


### PR DESCRIPTION
## Summary
- Adds a validation step to `update-major-tag.yml` that verifies the target tag points to a commit reachable from the `main` branch before updating the major tag
- Prevents major tags from pointing to off-main commits

## Test plan
- [ ] Trigger `update-major-tag` workflow with a tag pointing to a main-branch commit — should succeed
- [ ] Trigger `update-major-tag` workflow with a tag pointing to an off-main commit — should fail with a clear error

SNOW-3345166