### PR TITLE
Restrict update-major-tag workflow to repo admins only

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -17,6 +17,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Verify caller is a repo admin
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          if [[ "$PERMISSION" != "admin" ]]; then
+            echo "::error::Only repository admins can trigger this workflow. Current permission: $PERMISSION"
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Summary
- Adds an admin permission check at the start of the `update-major-tag` workflow
- Only repo admins can trigger tag updates — non-admins get a clear error
- Ensures engineers cannot publish directly; everything goes through the gated process

## Test plan
- [ ] Trigger `update-major-tag` as a repo admin — should proceed normally
- [ ] Trigger `update-major-tag` as a non-admin user — should fail with "Only repository admins can trigger this workflow"

SNOW-3345166