### PR TITLE
Fix cli-version: "latest" regression after pipx → uv migration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         exit 1
 
     - name: Install snowflake-cli (specific version)
-      if: ${{ inputs.cli-version != '' && inputs.custom-github-ref == '' }}
+      if: ${{ inputs.cli-version != '' && inputs.cli-version != 'latest' && inputs.custom-github-ref == '' }}
       shell: bash
       run: uv tool install snowflake-cli==${{ inputs.cli-version }}
 
@@ -66,7 +66,7 @@ runs:
       run: uv tool install "git+https://github.com/snowflakedb/snowflake-cli.git@${{ inputs.custom-github-ref }}"
 
     - name: Install snowflake-cli (latest release)
-      if: ${{ inputs.cli-version == '' && inputs.custom-github-ref == '' }}
+      if: ${{ (inputs.cli-version == '' || inputs.cli-version == 'latest') && inputs.custom-github-ref == '' }}
       shell: bash
       run: uv tool install snowflake-cli
 


### PR DESCRIPTION
## Summary

`uv tool install snowflake-cli==latest` is rejected by uv with `"expected version to start with a number"`. This breaks callers passing `cli-version: "latest"` — including the scheduled `CLI Action testing` workflow in `snowflakedb/snowflake-cli`, which has been failing nightly since the pipx → uv migration ([#53](https://github.com/snowflakedb/snowflake-cli-action/pull/53)).

PR [#51](https://github.com/snowflakedb/snowflake-cli-action/pull/51) previously fixed the same symptom in the pipx script by treating `CLI_VERSION=latest` as equivalent to omitting the version. That carve-out was lost in the uv rewrite. This restores it in the composite-action form.

## Changes

- `cli-version: "latest"` now routes to `uv tool install snowflake-cli` (same as omitting the input).
- Any real version spec (e.g. `"3.17.0"`) still hits the `==<version>` branch.
- `custom-github-ref` behavior is unchanged.

## Repro

```
$ uv tool install snowflake-cli==latest
error: Failed to parse: `snowflake-cli==latest`
  Caused by: expected version to start with a number, but no leading ASCII digits were found
```

Latest failing run on `snowflakedb/snowflake-cli` main: https://github.com/snowflakedb/snowflake-cli/actions/runs/25196061250

## Test plan

- [ ] Trigger `CLI Action testing` in `snowflake-cli` via `workflow_dispatch` against this branch (or merge + wait for the next nightly cron).
- [ ] Confirm the install step resolves to `uv tool install snowflake-cli` when `cli-version: latest`.
- [ ] Smoke test with an explicit version (`cli-version: "3.17.0"`) to ensure the pinned path still works.