### PR TITLE
Add scheduled latest-CLI compatibility workflow (SNOW-3428283)

### DIFF
--- a/.github/workflows/compat-latest-cli.yml
+++ b/.github/workflows/compat-latest-cli.yml
@@ -1,0 +1,49 @@
+name: Compatibility — latest Snowflake CLI
+
+# Runs the action against the latest published Snowflake CLI release on a
+# daily schedule so a CLI release that breaks the wrapper is detected within
+# the 48-hour SLO defined in the Native CI/CD Integrations ORR (§2.2, §7.4).
+#
+# Scheduled (not release-triggered) because the Snowflake CLI lives in a
+# different repository (snowflakedb/snowflake-cli); scheduling here avoids a
+# cross-repo release webhook. Daily cadence comfortably meets 48 h.
+
+on:
+  schedule:
+    # 06:17 UTC — slightly off the hour to avoid GitHub-Actions cron spikes.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install-latest:
+    name: Install latest CLI on ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.13']
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Snowflake CLI via this action (latest release)
+        uses: ./
+        # cli-version omitted → action installs the latest release from PyPI.
+
+      - name: Smoke-test installed CLI
+        shell: bash
+        run: |
+          set -e
+          snow --version
+          snow --help > /dev/null
+          snow connection list > /dev/null


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/compat-latest-cli.yml` runs this action daily against the latest Snowflake CLI release from PyPI (matrix: ubuntu/macos/windows × py3.10/3.13) and smoke-tests `snow --version`, `snow --help`, `snow connection list`.
- Addresses the pre-GA gap in the [Native CI/CD Integrations ORR](https://docs.google.com/document/d/1tIt17OqIhogc8KjijGL815kRI-F4x6Mw45NvnU8mloM) §2.2 / §7.4 — compatibility with a new CLI release is validated within 48 h.
- A red scheduled build on `main` is the L2-Critical trigger already defined in ORR §4.3; no new alerting plumbing is required.

## Why a schedule, not a release webhook on snowflake-cli?
- No cross-repo token / webhook to maintain in `snowflakedb/snowflake-cli`.
- Daily cadence comfortably meets the 48 h SLO.
- Symmetric with the approach used in the GitLab component and ADO extension siblings.

## Jira
- SNOW-3428283

## Test plan
- [ ] Merge and observe the first scheduled run (17:06 UTC next day) — matrix should be green against the current latest CLI.
- [ ] Manually `workflow_dispatch` once post-merge to validate the job executes end-to-end without waiting for the cron.
- [ ] Verify a failure (e.g. temporarily pin `cli-version` to a deleted version on a throwaway branch) lights the workflow red.