### PR TITLE
Deprecate snowflake-cli-action: migration notice to snowflake-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Snowflake CLI Github Actions
 
-**Note:** Snowflake CLI Github Actions is in Preview.
+> [!IMPORTANT]
+> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).**
+>
+> `snowflake-actions` is the new home for Snowflake's first-party GitHub Actions — this CLI setup action plus a growing family of sub-actions (DCM, and more) under one namespace. **`snowflakedb/snowflake-cli-action` is deprecated** and will be archived after a ~6-month migration window.
+>
+> **To migrate, swap your `uses:` line. The inputs are identical:**
+>
+> ```diff
+> - - uses: snowflakedb/snowflake-cli-action@v2
+> + - uses: snowflakedb/snowflake-actions@v2
+> ```
+>
+> Existing workflows pinned to `snowflake-cli-action` keep working during the migration window, and the underlying Snowflake CLI carries a minimum 2-year support policy — pinned workflows won't break at archive. See [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions) for the full list of actions and usage.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ﻿# action.yml
 name: "Install Snowflake CLI"
-description: "Download and install snowflake-cli"
+description: "[Deprecated — moved to snowflakedb/snowflake-actions] Download and install snowflake-cli"
 branding:
   icon: "terminal"
   color: "blue"


### PR DESCRIPTION
## What

Adds a deprecation / migration notice to the legacy `snowflake-cli-action` repo, pointing users to `snowflakedb/snowflake-actions`.

- **README:** prominent `[!IMPORTANT]` banner at the top — the action has moved, how to migrate (one-line `uses:` swap, identical inputs), and what the migration window guarantees.
- **action.yml:** `description` prefixed with `[Deprecated — moved to snowflakedb/snowflake-actions]` so the Marketplace listing reflects the move.

## Why

GA of the Snowflake GitHub Action completes the move from `snowflake-cli-action` to `snowflake-actions` (the home for a family of first-party sub-actions). This operationalizes the migration plan's "keep the old repo live with a deprecation notice" step. The old repo stays live through the approved ~6-month dual-location window, then is archived.

## ⚠️ Hold merge

Draft on purpose. **Merge with GA (target Jun 18) and only once the `snowflake-actions` Marketplace listing is verified ✓** — per the launch review, we don't broadcast the new URL before the verified badge lands (Marketplace squatter risk).