### PR TITLE
Move snowflake-cli-action to snowflake-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # Snowflake CLI Github Actions
 
 > [!IMPORTANT]
-> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).**
->
-> `snowflake-actions` is the new home for Snowflake's first-party GitHub Actions — this CLI setup action plus a growing family of sub-actions (DCM, and more) under one namespace. **`snowflakedb/snowflake-cli-action` is deprecated** and will be archived after a ~6-month migration window.
->
-> **To migrate, swap your `uses:` line. The inputs are identical:**
+> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions) and is deprecated.** To migrate, swap your `uses:` line — the inputs are identical:
 >
 > ```diff
 > - - uses: snowflakedb/snowflake-cli-action@v2
 > + - uses: snowflakedb/snowflake-actions@v2
 > ```
->
-> Existing workflows pinned to `snowflake-cli-action` keep working during the migration window, and the underlying Snowflake CLI carries a minimum 2-year support policy — pinned workflows won't break at archive. See [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions) for the full list of actions and usage.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Snowflake CLI Github Actions
 
-**Note:** Snowflake CLI Github Actions is in Preview.
+> [!IMPORTANT]
+> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).**
+>
+> `snowflake-actions` is the new home for Snowflake's first-party GitHub Actions — this CLI setup action plus a growing family of sub-actions (DCM, and more) under one namespace. **`snowflakedb/snowflake-cli-action` is deprecated** and will be archived after a ~6-month migration window.
+>
+> **To migrate, swap your `uses:` line. The inputs are identical:**
+>
+> ```diff
+> - - uses: snowflakedb/snowflake-cli-action@v2
+> + - uses: snowflakedb/snowflake-actions@v2
+> ```
+>
+> Existing workflows pinned to `snowflake-cli-action` keep working during the migration window, and the underlying Snowflake CLI carries a minimum 2-year support policy — pinned workflows won't break at archive. See [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions) for the full list of actions and usage.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 >
 > ```diff
 > - - uses: snowflakedb/snowflake-cli-action@v2
-> + - uses: snowflakedb/snowflake-actions@v2
+> + - uses: snowflakedb/snowflake-actions@v3
 > ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snowflake CLI Github Actions
 
 > [!IMPORTANT]
-> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).** Update your `uses:` line — the inputs are identical:
+> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).** To migrate, update your `uses:` line. The inputs are identical and no other changes are needed:
 >
 > ```diff
 > - - uses: snowflakedb/snowflake-cli-action@v2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snowflake CLI Github Actions
 
 > [!IMPORTANT]
-> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions) and is deprecated.** To migrate, swap your `uses:` line — the inputs are identical:
+> **This action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions).** Update your `uses:` line — the inputs are identical:
 >
 > ```diff
 > - - uses: snowflakedb/snowflake-cli-action@v2

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ﻿# action.yml
 name: "Install Snowflake CLI"
-description: "[Deprecated — moved to snowflakedb/snowflake-actions] Download and install snowflake-cli"
+description: "[Moved to snowflakedb/snowflake-actions] Download and install snowflake-cli"
 branding:
   icon: "terminal"
   color: "blue"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ﻿# action.yml
 name: "Install Snowflake CLI"
-description: "Download and install snowflake-cli"
+description: "[Deprecated — moved to snowflakedb/snowflake-actions] Download and install snowflake-cli"
 branding:
   icon: "terminal"
   color: "blue"


### PR DESCRIPTION
## Summary

- Adds a prominent `[!IMPORTANT]` migration banner to the README announcing that this action has moved to [`snowflakedb/snowflake-actions`](https://github.com/snowflakedb/snowflake-actions)
- Marks the `action.yml` description as `[Moved to snowflakedb/snowflake-actions]` so the deprecation is visible in the GitHub Actions marketplace
- Migration is a one-line `uses:` swap with identical inputs; no other changes needed

## Context

`snowflakedb/snowflake-actions` is the new unified home for Snowflake's first-party GitHub Actions. This repo (`snowflake-cli-action`) is being deprecated in favour of that namespace. Existing pinned workflows continue working during the ~6-month migration window and won't break at archive (Snowflake CLI carries a minimum 2-year support policy).

## Test plan

- [ ] README renders the migration banner correctly on GitHub
- [ ] `action.yml` description shows the deprecation label in the Marketplace listing
- [ ] Existing workflows using `snowflakedb/snowflake-cli-action@v2` still pass (no functional changes)

Made with [Cursor](https://cursor.com)